### PR TITLE
Exclude build artifacts from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,7 @@ Thumbs.db
 *.dll
 *.exe
 
+# Build artifacts
+.cache
+build
+releases


### PR DESCRIPTION
Building locally, my repo was full of 2k+ changes simply because of these build artifacts.
I suggest to add these to the `.gitignore` to keep the repo clean to work with.