### PR TITLE
Feature/improve input clearing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,7 @@ Thumbs.db
 *.dll
 *.exe
 
+# Build artifacts
+.cache
+build
+releases

--- a/AppGrid.qml
+++ b/AppGrid.qml
@@ -130,6 +130,21 @@ Page {
                     property: "textInput"
                     value: textField.displayText.toLowerCase()
                 }
+
+                Button {
+                    id: deleteButton
+                    text: "<font color='#808080'>×</font>"
+                    font.pointSize: mainView.largeFontSize * 2
+                    flat: true
+                    topPadding: 0.0
+                    anchors.top: parent.top
+                    anchors.right: parent.right
+
+                    onClicked: {
+                        textField.text = ""
+                        textField.focus = false
+                    }
+                }
             }
             Rectangle {
                 width: parent.width

--- a/AppGrid.qml
+++ b/AppGrid.qml
@@ -139,6 +139,7 @@ Page {
                     topPadding: 0.0
                     anchors.top: parent.top
                     anchors.right: parent.right
+                    visible: textField.displayText !== ""
 
                     onClicked: {
                         textField.text = ""

--- a/Collections.qml
+++ b/Collections.qml
@@ -175,13 +175,13 @@ Page {
                 }
                 Button {
                     id: deleteButton
-                    visible: textField.activeFocus
                     text: "<font color='#808080'>×</font>"
                     font.pointSize: mainView.largeFontSize * 2
                     flat: true
                     topPadding: 0.0
                     anchors.top: parent.top
                     anchors.right: parent.right
+                    visible: textField.displayText !== ""
 
                     onClicked: {
                         textField.text = ""
@@ -918,7 +918,7 @@ Page {
                             console.log("Collections | Received header status of " + rssFeed.name + ": " + doc.status);
                             if (doc.status !== 200) {
                                 mainView.updateSpinner(false)
-                                mainView.showToast(qsTr("Could not load RSS feed " + rssFeed.name))
+                                mainView.showToast(qsTr("Could not load RSS feed: ") + rssFeed.name)
                             }
                         } else if (doc.readyState === XMLHttpRequest.DONE) {
                             var cNews = {c_CHANNEL: rssFeed.id}

--- a/Conversation.qml
+++ b/Conversation.qml
@@ -228,13 +228,13 @@ Page {
                 }
                 Button {
                     id: deleteButton
-                    visible: textField.activeFocus
                     text: "<font color='#808080'>×</font>"
                     font.pointSize: mainView.largeFontSize * 2
                     flat: true
                     topPadding: 0.0
                     anchors.top: parent.top
                     anchors.right: parent.right
+                    visible: textField.displayText !== ""
 
                     onClicked: {
                         textField.text = ""

--- a/Feed.qml
+++ b/Feed.qml
@@ -181,13 +181,13 @@ Page {
                     }
                     Button {
                         id: deleteButton
-                        visible: textField.activeFocus
                         text: "<font color='#808080'>×</font>"
                         font.pointSize: mainView.largeFontSize * 2
                         flat: true
                         topPadding: 0.0
                         anchors.top: parent.top
                         anchors.right: parent.right
+                        visible: textField.displayText !== ""
 
                         onClicked: {
                             textField.text = ""

--- a/Springboard.qml
+++ b/Springboard.qml
@@ -104,6 +104,7 @@ Page {
                     topPadding: 0.0
                     anchors.top: parent.top
                     anchors.right: parent.right
+                    visible: textArea.preeditText !== "" || textArea.text !== ""
 
                     onClicked: {
                         textArea.text = ""


### PR DESCRIPTION
As suggested in [Issue 26](https://github.com/HelloVolla/android-launcher-qt/issues/26), the search-input in the AppGrid now has a "clear"-button, too.

Additionally, the clear-buttons on AppGrid and Springboard are now hidden unless the corresponding input contains text (which is the default behavior in android).