### PR TITLE
Fixing Note lines

### DIFF
--- a/Details.qml
+++ b/Details.qml
@@ -358,7 +358,7 @@ Page {
                     detailPage.prepareNoteView(plainText, lastCurserPosition)
                     mainView.updateNote(detailPage.currentDetailId, plainText, detailPage.currentDetailHasBadge)
                 }
-                if (lastCurserPosition === detailEdit.cursorPosition) isBlocked = false
+                if (lastCurserPosition === detailEdit.cursorPosition) isBlocked = true
             }
 
             onActiveFocusChanged: {


### PR DESCRIPTION
Fixing Note lines deleted while editing,
    The code inside isBlocked is causing the cursor shift left leading to some text got deleted,
    verified with isBlocked=true nad issue id not reproducible