### PR TITLE
AppGrid: Migrate to margins for context menu items

### DIFF
--- a/AppGrid.qml
+++ b/AppGrid.qml
@@ -361,6 +361,7 @@ LauncherPage {
 
         MenuItem {
             id: addShortCutItem
+            anchors.margins: mainView.innerSpacing
             text: qsTr("Add to shortcuts")
             font.pointSize: appLauncher.labelPointSize
             contentItem: Label {
@@ -369,9 +370,6 @@ LauncherPage {
                 font: addShortCutItem.font
                 horizontalAlignment: Text.AlignHCenter
             }
-            leftPadding: mainView.innerSpacing
-            rightPadding: mainView.innerSpacing
-            topPadding: mainView.innerSpacing
             background: Rectangle {
                 anchors.fill: parent
                 color: "transparent"
@@ -389,15 +387,13 @@ LauncherPage {
         }
         MenuItem {
             id: openAppItem
+            anchors.margins: mainView.innerSpacing
             font.pointSize: appLauncher.labelPointSize
             contentItem: Label {
                 width: contextMenu.menuWidth
                 text: contextMenu.isPinnedShortcut ? qsTr("Open Shortcut") : qsTr("Open App")
                 horizontalAlignment: Text.AlignHCenter
             }
-            leftPadding: mainView.innerSpacing
-            rightPadding: mainView.innerSpacing
-            bottomPadding: removeAppItem.visible ? 0 : mainView.innerSpacing
             background: Rectangle {
                 anchors.fill: parent
                 color: "transparent"
@@ -423,6 +419,7 @@ LauncherPage {
         }
         MenuItem {
             id: removeAppItem
+            anchors.margins: mainView.innerSpacing
             height: removeAppItem.visible ? contextMenu.menuItemHeight : 0
             font.pointSize: appLauncher.labelPointSize
             contentItem: Label {
@@ -430,9 +427,6 @@ LauncherPage {
                 text: qsTr("Remove App")
                 horizontalAlignment: Text.AlignHCenter
             }
-            leftPadding: mainView.innerSpacing
-            rightPadding: mainView.innerSpacing
-            bottomPadding: mainView.innerSpacing
             background: Rectangle {
                 anchors.fill: parent
                 color: "transparent"
@@ -444,6 +438,7 @@ LauncherPage {
         }
         MenuItem {
             id: removePinnedShortcutItem
+            anchors.margins: mainView.innerSpacing
             height: removePinnedShortcutItem.visible ? contextMenu.menuItemHeight : 0
             font.pointSize: appLauncher.labelPointSize
             contentItem: Label {
@@ -451,9 +446,6 @@ LauncherPage {
                 text: qsTr("Remove Bookmark")
                 horizontalAlignment: Text.AlignHCenter
             }
-            leftPadding: mainView.innerSpacing
-            rightPadding: mainView.innerSpacing
-            bottomPadding: mainView.innerSpacing
             background: Rectangle {
                 anchors.fill: parent
                 color: "transparent"


### PR DESCRIPTION
It fix bad context menu style, which was created at 9a109146c7bc9c82d1a88f14165c8ebbdfcdf7a6.