### PR TITLE
security: Use HTTPS for all network requests instead of HTTP

### DIFF
--- a/Details.qml
+++ b/Details.qml
@@ -213,7 +213,7 @@ LauncherPage {
         var styledText = note.slice()
         var urlRegex = /(((https?:\/\/)|([^\s]+\.))[^\s,]+)/g;
         styledText = styledText.replace(urlRegex, function(url,b,c) {
-            var url2 = !c.startsWith('http') ?  'http://' + url : url;
+            var url2 = !c.startsWith('http') ?  'https://' + url : url;
             return '<a href="' +url2+ '" target="_blank">' + url + '</a>';
         })
 

--- a/Springboard.qml
+++ b/Springboard.qml
@@ -1084,7 +1084,7 @@ LauncherPage {
 
                  function getGeoCodes(city) {
                      console.debug("Widget | Will request cities: " + city)
-                     var geoUrl = "http://api.openweathermap.org/geo/1.0/direct?q=" + city + "&limit=20&appid=" + weatherWidget.apiKey
+                     var geoUrl = "https://api.openweathermap.org/geo/1.0/direct?q=" + city + "&limit=20&appid=" + weatherWidget.apiKey
                      geoRequest.onreadystatechange = function() {
                          if (geoRequest.readyState === XMLHttpRequest.DONE) {
                              console.debug("Widget | Geo location response: " + geoRequest.status)
@@ -1114,7 +1114,7 @@ LauncherPage {
 
             function getLocation() {
                 console.debug("Widget | Will request city name for " + weatherWidget.latitude, weatherWidget.longitude)
-                var cityUrl = "http://api.openweathermap.org/geo/1.0/reverse?lat="
+                var cityUrl = "https://api.openweathermap.org/geo/1.0/reverse?lat="
                         + weatherWidget.latitude + "&lon=" + weatherWidget.longitude + "&appid=" + apiKey
                 var cityRequest = new XMLHttpRequest()
                 cityRequest.onreadystatechange = function() {


### PR DESCRIPTION
This PR improves the security posture of the application by replacing all insecure http:// URLs with https:// wherever applicable. This affects both hardcoded URLs and dynamically generated ones used in:
API requests (e.g., OpenWeatherMap)
User-facing text (auto-linking)
WebView sources and links


Note: Needs to be tested with release apk @wurzer @arvibuddy 
